### PR TITLE
update cli

### DIFF
--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -80,8 +80,6 @@ export async function runWalletReceiveCredential(ctx: CommandContext): Promise<v
   const request = {
     offerUrl: ctx.ctx.offerId,
     keyReference: ctx.ctx.walletKeyRef,
-    runPolicies: false,
-    useClientAttestation: true,
   };
   ctx.saveJson('wallet-receive-request.json', request, step);
 
@@ -91,7 +89,11 @@ export async function runWalletReceiveCredential(ctx: CommandContext): Promise<v
   );
   ctx.saveJson('wallet-receive-response.json', response.data, step);
 
-  const receivedCount = Array.isArray(response.data) ? response.data.length : 0;
+  const receivedCount = Array.isArray(response.data)
+    ? response.data.length
+    : Array.isArray(response.data?.credentialIds)
+      ? response.data.credentialIds.length
+      : 0;
   console.log(`   [OK] Credential received (count: ${receivedCount})`);
 }
 
@@ -164,7 +166,7 @@ export async function runCreateVerificationSession(
   ctx.saveJson('create-verification-session-request.json', request, step);
 
   const response = await ctx.orgClient.post(
-    `/v1/${ctx.tenantPath}.${RESOURCES.verifier2}/verifier2-service-api/verification-session/create`,
+    `/v2/${ctx.tenantPath}.${RESOURCES.verifier2}/verifier-service-api/verification-session/create`,
     request
   );
   ctx.saveJson('create-verification-session-response.json', response.data, step);
@@ -181,29 +183,20 @@ export async function runCreateVerificationSession(
 }
 
 /** Wallet presents credential */
-export async function runWalletPresent(ctx: CommandContext, credentialIds: string[] = []): Promise<void> {
+export async function runWalletPresent(ctx: CommandContext, _credentialIds: string[] = []): Promise<void> {
   const step = ctx.nextStep();
   ctx.log('Wallet presents credential', 'RUN');
 
-  const request: {
-    requestUrl: string;
-    keyReference: string;
-    didReference: string;
-    credentials?: Array<{ credential: string }>;
-  } = {
+  const request = {
     requestUrl: ctx.ctx.requestUrl,
     keyReference: ctx.ctx.walletKeyRef,
-    didReference: ctx.ctx.walletDid || defaultWalletDidReference(ctx.tenantPath),
+    did: ctx.ctx.walletDid || defaultWalletDidReference(ctx.tenantPath),
   };
-
-  if (credentialIds.length > 0) {
-    request.credentials = credentialIds.map(credential => ({ credential }));
-  }
 
   ctx.saveJson('wallet-present-request.json', request, step);
 
   const response = await ctx.orgClient.post(
-    `/v1/${ctx.tenantPath}.${RESOURCES.wallet}/wallet-service-api/credentials/present`,
+    `/v2/${ctx.tenantPath}.${RESOURCES.wallet}/wallet-service-api/credentials/present`,
     request
   );
   ctx.saveJson('wallet-present-response.json', response.data, step);
@@ -221,7 +214,7 @@ export async function runAssertFinalStatus(
   ctx.log('Check verifier2 final session status', 'RUN');
 
   const response = await ctx.orgClient.get(
-    `/v1/${verifierPath}.${ctx.ctx.sessionId}/verifier2-service-api/verification-session/info`
+    `/v2/${verifierPath}.${ctx.ctx.sessionId}/verifier-service-api/verification-session/info`
   );
   ctx.saveJson(fileName, response.data, step);
 
@@ -244,7 +237,7 @@ export async function runAssertFinalStatusFailed(
   ctx.log('Check verifier2 final session status (expecting FAILED)', 'RUN');
 
   const response = await ctx.orgClient.get(
-    `/v1/${verifierPath}.${ctx.ctx.sessionId}/verifier2-service-api/verification-session/info`
+    `/v2/${verifierPath}.${ctx.ctx.sessionId}/verifier-service-api/verification-session/info`
   );
   ctx.saveJson(fileName, response.data, step);
 

--- a/cli/src/commands/setup/bank-tenant.ts
+++ b/cli/src/commands/setup/bank-tenant.ts
@@ -7,7 +7,7 @@
  */
 
 import { CommandContext } from '../../context.js';
-import { RESOURCES, KEY_IDS, CERT_IDS, defaultWalletKeyReference, defaultWalletDidReference } from '../../config.js';
+import { RESOURCES, KEY_IDS, CERT_IDS } from '../../config.js';
 import {
   BankTenantConfig,
   buildBankIssuerServiceConfig,
@@ -19,6 +19,7 @@ import {
 import { setupLogin } from './auth.js';
 import {
   setupCreateTenant,
+  setupCreateWallet,
   setupCreateServices,
   setupLinkX509Dependencies,
 } from './tenant.js';
@@ -79,52 +80,14 @@ async function buildMdocX5Chain(
 
 /**
  * Initialize wallet with its own KMS (separate from issuer KMS), DID service/store,
- * credential store, and did:key. Uses init-wallet wizard (wallet-service setup docs).
+ * credential store, and did:key via Wallet2 composable init.
  */
 export async function setupBankCreateWallet(ctx: CommandContext): Promise<void> {
-  const step = ctx.nextStep();
   ctx.log('Initialize bank tenant wallet with dedicated KMS and DID', 'BANK-SETUP');
-
+  await setupCreateWallet(ctx, 'key');
   const walletKmsRef = `${ctx.tenantPath}.${RESOURCES.walletKms}`;
-
-  const { created } = await ctx.tolerantCreate(
-    'Wallet',
-    async () => {
-      const request = {
-        createKms: true,
-        kmsName: RESOURCES.walletKms,
-        createKeyInKms: {
-          keyType: 'secp256r1',
-        },
-        createDidStore: true,
-        didStoreName: RESOURCES.walletDidStore,
-        createDidService: true,
-        didServiceName: RESOURCES.walletDidService,
-        createDidWithDidService: 'key',
-        createCredentialStore: true,
-        credentialStoreName: RESOURCES.walletCredentialStore,
-      };
-      ctx.saveJson('init-bank-wallet-request.json', request, step);
-
-      const response = await ctx.orgClient.post(
-        `/v1/${ctx.tenantPath}/wallet-service-api/init-wallet`,
-        request
-      );
-      ctx.saveJson('init-bank-wallet-response.json', response.data, step);
-      return response;
-    }
-  );
-
-  ctx.ctx.walletKeyRef = defaultWalletKeyReference(ctx.tenantPath);
-  ctx.ctx.walletDid = defaultWalletDidReference(ctx.tenantPath);
-
-  if (created) {
-    console.log(`   [OK] Wallet initialized (KMS: ${walletKmsRef})`);
-    if (ctx.ctx.walletDid) {
-      console.log(`   [OK] Wallet DID: ${ctx.ctx.walletDid}`);
-    }
-  } else if (ctx.ctx.walletDid) {
-    console.log(`   [SKIP] Wallet already exists (DID: ${ctx.ctx.walletDid})`);
+  if (ctx.ctx.walletDid) {
+    console.log(`   [OK] Wallet DID: ${ctx.ctx.walletDid} (KMS: ${walletKmsRef})`);
   }
 }
 

--- a/cli/src/commands/setup/gov-services.ts
+++ b/cli/src/commands/setup/gov-services.ts
@@ -10,7 +10,7 @@
  */
 
 import { CommandContext } from '../../context.js';
-import { RESOURCES, CERT_IDS, KEY_IDS, defaultWalletKeyReference, defaultWalletDidReference } from '../../config.js';
+import { RESOURCES, CERT_IDS, KEY_IDS } from '../../config.js';
 import {
   GovServicesConfig,
   DepartmentConfig,
@@ -30,6 +30,7 @@ import {
 import { setupLogin } from './auth.js';
 import {
   setupCreateTenant,
+  setupCreateWallet,
   setupCreateServices,
   setupLinkX509Dependencies,
 } from './tenant.js';
@@ -266,10 +267,9 @@ async function linkDidServiceDependencies(ctx: CommandContext): Promise<void> {
 
   // Link KMS to DID service
   try {
-    await ctx.orgClient.post(
+    await ctx.addServiceDependency(
       `/v1/${ctx.tenantPath}.${RESOURCES.didService}/did-service-api/dids/dependencies/add`,
-      `${ctx.tenantPath}.${RESOURCES.kms}`,
-      'text/plain'
+      `${ctx.tenantPath}.${RESOURCES.kms}`
     );
     console.log(`   [OK] Linked KMS to DID service`);
   } catch (error: any) {
@@ -282,10 +282,9 @@ async function linkDidServiceDependencies(ctx: CommandContext): Promise<void> {
 
   // Link DID store to DID service
   try {
-    await ctx.orgClient.post(
+    await ctx.addServiceDependency(
       `/v1/${ctx.tenantPath}.${RESOURCES.didService}/did-service-api/dids/dependencies/add`,
-      `${ctx.tenantPath}.${RESOURCES.didStore}`,
-      'text/plain'
+      `${ctx.tenantPath}.${RESOURCES.didStore}`
     );
     console.log(`   [OK] Linked DID store to DID service`);
   } catch (error: any) {
@@ -309,7 +308,7 @@ async function createDepartmentDid(
   const createResponse = await ctx.orgClient.post(
     `/v1/${ctx.tenantPath}.${RESOURCES.didService}/did-service-api/dids/create/key`,
     {
-      keyId: dept.signingKeyId,
+      keyReference: dept.signingKeyId,
     }
   );
 
@@ -513,8 +512,8 @@ async function linkGovVerifierToTrustRegistry(ctx: CommandContext): Promise<void
   const verifierTarget = `${ctx.tenantPath}.${RESOURCES.verifier2}`;
 
   try {
-    await ctx.orgClient.postRaw(
-      `/v1/${verifierTarget}/verifier2-service-api/dependencies/add`,
+    await ctx.addServiceDependency(
+      `/v2/${verifierTarget}/verifier-service-api/dependencies/add`,
       trustRegistryTarget
     );
     console.log(`   [OK] Trust registry linked to verifier`);
@@ -852,45 +851,8 @@ async function createGovVerifier(
 
 /** Initialize wallet for central government tenant */
 async function createGovWallet(ctx: CommandContext): Promise<void> {
-  const step = ctx.nextStep();
   ctx.log('Initialize central government wallet with holder DID', 'GOV-SETUP');
-
-  const { created } = await ctx.tolerantCreate(
-    'Wallet',
-    async () => {
-      const request = {
-        createKms: true,
-        kmsName: RESOURCES.walletKms,
-        createKeyInKms: {
-          keyType: 'secp256r1',
-        },
-        createDidStore: true,
-        didStoreName: RESOURCES.walletDidStore,
-        createDidService: true,
-        didServiceName: RESOURCES.walletDidService,
-        createDidWithDidService: 'key',
-        createCredentialStore: true,
-        credentialStoreName: RESOURCES.walletCredentialStore,
-      };
-      ctx.saveJson('init-gov-wallet-request.json', request, step);
-
-      const response = await ctx.orgClient.post(
-        `/v1/${ctx.tenantPath}/wallet-service-api/init-wallet`,
-        request
-      );
-      ctx.saveJson('init-gov-wallet-response.json', response.data, step);
-      return response;
-    }
-  );
-
-  ctx.ctx.walletKeyRef = defaultWalletKeyReference(ctx.tenantPath);
-  ctx.ctx.walletDid = defaultWalletDidReference(ctx.tenantPath);
-
-  if (created) {
-    console.log(`   [OK] Wallet initialized`);
-  } else {
-    console.log(`   [SKIP] Wallet already exists (DID reference: ${ctx.ctx.tenantPath})`);
-  }
+  await setupCreateWallet(ctx, 'key');
 }
 
 /**

--- a/cli/src/commands/setup/issuer.ts
+++ b/cli/src/commands/setup/issuer.ts
@@ -98,7 +98,7 @@ export async function setupCreateClientAttester(ctx: CommandContext): Promise<vo
 
   // Add KMS dependency
   try {
-    await ctx.orgClient.postRaw(
+    await ctx.addServiceDependency(
       `/v1/${ctx.tenantPath}.${RESOURCES.clientAttester}/client-attester-api/dependencies/add`,
       `${ctx.tenantPath}.${RESOURCES.kms}`
     );
@@ -275,8 +275,8 @@ export async function setupLinkWalletToAttester(ctx: CommandContext): Promise<vo
   ctx.log('Attach client attester dependency to wallet', 'SETUP');
 
   try {
-    await ctx.orgClient.postRaw(
-      `/v1/${ctx.tenantPath}.${RESOURCES.wallet}/wallet-service-api/dependencies/add`,
+    await ctx.addServiceDependency(
+      `/v2/${ctx.tenantPath}.${RESOURCES.wallet}/wallet-service-api/dependencies/add`,
       `${ctx.tenantPath}.${RESOURCES.clientAttester}`
     );
     console.log(`   [OK] Client attester linked to wallet`);
@@ -301,7 +301,7 @@ export async function setupObtainWalletAttestation(ctx: CommandContext): Promise
   ctx.saveJson('obtain-attestation-request.json', request, step);
 
   const response = await ctx.orgClient.post(
-    `/v1/${ctx.tenantPath}.${RESOURCES.wallet}/wallet-service-api/client-attestation/obtain`,
+    `/v2/${ctx.tenantPath}.${RESOURCES.wallet}/wallet-service-api/client-attestation/obtain`,
     request
   );
   ctx.saveJson('obtain-attestation-response.json', response.data, step);

--- a/cli/src/commands/setup/oidc-bridge.ts
+++ b/cli/src/commands/setup/oidc-bridge.ts
@@ -40,6 +40,9 @@ export async function setupCreateOidcBridge(ctx: CommandContext): Promise<void> 
   console.log(`   [INFO] Issuer URL: ${issuerUrl}`);
   console.log(`   [INFO] Client ID: ${clientId}`);
   console.log(`   [INFO] Redirect URI: ${redirectUri}`);
+  if (!issuerUrl.startsWith('https://')) {
+    console.log('   [INFO] DC API flow disabled: expectedOrigins require HTTPS');
+  }
   
   // Base DCQL query used for all flows.
   // Matches the working reference config used in production demos:
@@ -111,6 +114,8 @@ export async function setupCreateOidcBridge(ctx: CommandContext): Promise<void> 
     url_config: {},
   };
   
+  const dcApiOriginIsHttps = issuerUrl.startsWith('https://');
+
   // Multi-flow configuration: enables all four presentation flows
   const flows = {
     // QR Code flow: Cross-device presentation (scan QR with mobile wallet)
@@ -121,26 +126,28 @@ export async function setupCreateOidcBridge(ctx: CommandContext): Promise<void> 
     },
     // Digital Credentials API flow: Browser-native credential picker
     dc_api: {
-      enabled: true,
+      enabled: dcApiOriginIsHttps,
       buttonLabel: 'Browser Wallet (Digital Credentials API)',
-      // DC API requires its own verification setup with expectedOrigins
-      verificationSetup: {
-        flow_type: 'dc_api',
-        core: {
-          dcql_query: baseDcqlQuery,
-          // signed_request / encrypted_response stay `false` to match the
-          // working reference config in waltid-identity-enterprise/ory/docs.
-          signed_request: false,
-          encrypted_response: false,
-          policies: {},
-          clientId: 'x509_hash:kZ5SI3MAFaLDPRxza8xguw-o6b8LYfmP2ZvrqVSRWng',
-          key: signingKey,
-          x5c: certificateChain,
-        },
-        // Expected origins for DC API - must match the page origin where credential.get() is called
-        expectedOrigins: [issuerUrl],
-        haip: false,
-      },
+      // DC API requires its own verification setup with HTTPS expectedOrigins.
+      // flow_type `dc_api` was replaced by `dc_api_openid4vp` (OpenID4VP Annex D).
+      ...(dcApiOriginIsHttps
+        ? {
+            verificationSetup: {
+              flow_type: 'dc_api_openid4vp',
+              core_flow: {
+                dcql_query: baseDcqlQuery,
+                signed_request: false,
+                encrypted_response: false,
+                policies: {},
+                clientId: 'x509_hash:kZ5SI3MAFaLDPRxza8xguw-o6b8LYfmP2ZvrqVSRWng',
+                key: signingKey,
+                x5c: certificateChain,
+              },
+              expectedOrigins: [issuerUrl],
+              haip: false,
+            },
+          }
+        : {}),
     },
     // Deep Link flow: Same-device mobile wallet launch (openid4vp://)
     deep_link: {

--- a/cli/src/commands/setup/status.ts
+++ b/cli/src/commands/setup/status.ts
@@ -43,10 +43,9 @@ export async function setupCreateCredentialStatusService(ctx: CommandContext): P
 
   // Link KMS dependency
   try {
-    await ctx.orgClient.post(
+    await ctx.addServiceDependency(
       `/v1/${ctx.tenantPath}.${RESOURCES.credentialStatus}/credential-status-service-api/dependencies/add`,
-      `${ctx.tenantPath}.${RESOURCES.kms}`,
-      'text/plain'
+      `${ctx.tenantPath}.${RESOURCES.kms}`
     );
     console.log(`   [OK] Linked KMS to credential status service`);
   } catch (error: any) {
@@ -109,10 +108,9 @@ export async function setupLinkIssuerToCredentialStatus(ctx: CommandContext): Pr
   ctx.log('Link credential status service to issuer', 'SETUP');
 
   try {
-    await ctx.orgClient.post(
+    await ctx.addServiceDependency(
       `/v2/${ctx.tenantPath}.${RESOURCES.issuer}/issuer-service-api/dependencies/add`,
-      `${ctx.tenantPath}.${RESOURCES.credentialStatus}`,
-      'text/plain'
+      `${ctx.tenantPath}.${RESOURCES.credentialStatus}`
     );
     console.log(`   [OK] Credential status service linked to issuer`);
   } catch (error: any) {

--- a/cli/src/commands/setup/tenant.ts
+++ b/cli/src/commands/setup/tenant.ts
@@ -9,7 +9,63 @@
  */
 
 import { CommandContext } from '../../context.js';
-import { RESOURCES, defaultWalletKeyReference, defaultWalletDidReference } from '../../config.js';
+import { RESOURCES, WALLET_DEFAULT_IDS, defaultWalletKeyReference, defaultWalletDidReference } from '../../config.js';
+
+/** Wallet DID method used by composable init (`did:jwk` or `did:key`). */
+export type WalletDidType = 'jwk' | 'key' | 'web';
+
+/**
+ * Build the Wallet2 composable-init body that replaced legacy `init-wallet`.
+ * Creates wallet2 + dedicated KMS/key, DID store/service, and credential store.
+ */
+export function buildWalletComposableInitRequest(
+  ctx: CommandContext,
+  didType: WalletDidType = 'jwk'
+): Record<string, unknown> {
+  const tenant = ctx.tenantPath;
+  const walletTarget = `${tenant}.${RESOURCES.wallet}`;
+  const kmsTarget = `${tenant}.${RESOURCES.walletKms}`;
+  const didStoreTarget = `${tenant}.${RESOURCES.walletDidStore}`;
+  const didServiceTarget = `${tenant}.${RESOURCES.walletDidService}`;
+  const credentialStoreTarget = `${tenant}.${RESOURCES.walletCredentialStore}`;
+
+  return {
+    wallet: {
+      createIfNotFound: true,
+      target: walletTarget,
+      kms: {
+        createIfNotFound: true,
+        target: kmsTarget,
+        key: {
+          createIfNotFound: true,
+          target: `${kmsTarget}.${WALLET_DEFAULT_IDS.key}`,
+          config: {
+            backend: 'jwk',
+            keyType: 'secp256r1',
+          },
+        },
+      },
+      didStore: {
+        createIfNotFound: true,
+        target: didStoreTarget,
+      },
+      didService: {
+        createIfNotFound: true,
+        target: didServiceTarget,
+        dependencies: [kmsTarget, didStoreTarget],
+        did: {
+          createIfNotFound: true,
+          target: `${didStoreTarget}.${WALLET_DEFAULT_IDS.did}`,
+          type: didType,
+        },
+      },
+      credentialStore: {
+        createIfNotFound: true,
+        target: credentialStoreTarget,
+      },
+    },
+  };
+}
 
 /** Create tenant */
 export async function setupCreateTenant(ctx: CommandContext): Promise<void> {
@@ -36,28 +92,22 @@ export async function setupCreateTenant(ctx: CommandContext): Promise<void> {
   }
 }
 
-/** Initialize wallet service */
-export async function setupCreateWallet(ctx: CommandContext): Promise<void> {
+/** Initialize Wallet2 service and supporting stores via composable init */
+export async function setupCreateWallet(
+  ctx: CommandContext,
+  didType: WalletDidType = 'jwk'
+): Promise<void> {
   const step = ctx.nextStep();
   ctx.log('Initialize wallet', 'SETUP');
   
   const { created } = await ctx.tolerantCreate(
     'Wallet',
     async () => {
-      const request = {
-        createKeyInKms: {
-          keyType: 'secp256r1',
-        },
-        createDidWithDidService: 'jwk',
-        kmsName: RESOURCES.walletKms,
-        didStoreName: RESOURCES.walletDidStore,
-        didServiceName: RESOURCES.walletDidService,
-        credentialStoreName: RESOURCES.walletCredentialStore,
-      };
+      const request = buildWalletComposableInitRequest(ctx, didType);
       ctx.saveJson('init-wallet-request.json', request, step);
 
       const response = await ctx.orgClient.post(
-        `/v1/${ctx.tenantPath}/wallet-service-api/init-wallet`,
+        `/v1/${ctx.tenantPath}/resource-api/services/init`,
         request
       );
       ctx.saveJson('init-wallet-response.json', response.data, step);
@@ -65,7 +115,6 @@ export async function setupCreateWallet(ctx: CommandContext): Promise<void> {
     }
   );
 
-  // Set wallet key reference
   ctx.ctx.walletKeyRef = defaultWalletKeyReference(ctx.tenantPath);
   ctx.ctx.walletDid = defaultWalletDidReference(ctx.tenantPath);
 
@@ -140,10 +189,9 @@ export async function setupLinkX509Dependencies(ctx: CommandContext): Promise<vo
 
   // Link KMS to x509-service
   try {
-    await ctx.orgClient.post(
+    await ctx.addServiceDependency(
       `/v1/${ctx.tenantPath}.${RESOURCES.x509Service}/x509-service-api/dependencies/add`,
-      `${ctx.tenantPath}.${RESOURCES.kms}`,
-      'text/plain'
+      `${ctx.tenantPath}.${RESOURCES.kms}`
     );
     console.log(`   [OK] Linked KMS to x509-service`);
   } catch (error: any) {
@@ -156,10 +204,9 @@ export async function setupLinkX509Dependencies(ctx: CommandContext): Promise<vo
 
   // Link x509-store to x509-service
   try {
-    await ctx.orgClient.post(
+    await ctx.addServiceDependency(
       `/v1/${ctx.tenantPath}.${RESOURCES.x509Service}/x509-service-api/dependencies/add`,
-      `${ctx.tenantPath}.${RESOURCES.x509Store}`,
-      'text/plain'
+      `${ctx.tenantPath}.${RESOURCES.x509Store}`
     );
     console.log(`   [OK] Linked x509-store to x509-service`);
   } catch (error: any) {

--- a/cli/src/commands/setup/trust.ts
+++ b/cli/src/commands/setup/trust.ts
@@ -82,8 +82,8 @@ export async function linkVerifier2ToTrustRegistry(ctx: CommandContext): Promise
   const verifier2Target = `${ctx.tenantPath}.${RESOURCES.verifier2}`;
 
   try {
-    await ctx.orgClient.postRaw(
-      `/v1/${verifier2Target}/verifier2-service-api/dependencies/add`,
+    await ctx.addServiceDependency(
+      `/v2/${verifier2Target}/verifier-service-api/dependencies/add`,
       trustRegistryTarget
     );
     console.log(`   [OK] Trust registry linked to verifier2: ${trustRegistryTarget}`);

--- a/cli/src/commands/system.ts
+++ b/cli/src/commands/system.ts
@@ -84,7 +84,9 @@ export async function createSuperadminAccount(ctx: CommandContext): Promise<bool
         'accept': '*/*',
         'Content-Type': 'application/json',
       },
-      body: token,
+      body: JSON.stringify({
+        "token" : token,
+      }),
     });
     
     const text = await response.text();
@@ -128,7 +130,7 @@ export async function initDb(ctx: CommandContext): Promise<void> {
     throw new Error('Could not get superadmin token for database init');
   }
   
-  const initResponse = await fetch(`${adminUrl}/v1/admin/initial-setup`, {
+  const initResponse = await fetch(`${adminUrl}/v1/dev/initial-setup`, {
     method: 'POST',
     headers: { 
       'accept': '*/*',

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -49,7 +49,7 @@ export const KEY_IDS = {
   attesterSigningKey: 'attester-signing-key',
 } as const;
 
-/** Default IDs created by wallet-service init-wallet */
+/** Default IDs created by Wallet2 composable init */
 export const WALLET_DEFAULT_IDS = {
   key: 'wallet_key',
   did: 'wallet_did',
@@ -259,12 +259,12 @@ export function defaultHostAliasTarget(organization: string): string {
   return `${organization}.host-alias`;
 }
 
-/** Default wallet key reference created by init-wallet */
+/** Default wallet key reference created by Wallet2 composable init */
 export function defaultWalletKeyReference(tenantPath: string): string {
   return `${tenantPath}.${RESOURCES.walletKms}.${WALLET_DEFAULT_IDS.key}`;
 }
 
-/** Default wallet DID reference created by init-wallet */
+/** Default wallet DID reference created by Wallet2 composable init */
 export function defaultWalletDidReference(tenantPath: string): string {
   return `${tenantPath}.${RESOURCES.walletDidStore}.${WALLET_DEFAULT_IDS.did}`;
 }

--- a/cli/src/context.ts
+++ b/cli/src/context.ts
@@ -215,6 +215,14 @@ export class CommandContext {
     }
   }
 
+  /**
+   * Attach a service dependency. The API expects JSON `{ dependency: "<target path>" }`,
+   * not a raw text/plain path string.
+   */
+  async addServiceDependency(dependenciesAddPath: string, dependencyPath: string): Promise<void> {
+    await this.orgClient.post(dependenciesAddPath, { dependency: dependencyPath });
+  }
+
   // --------------------------------------------------------------------------
   // Token Management
   // --------------------------------------------------------------------------

--- a/cli/src/flows/etsi.ts
+++ b/cli/src/flows/etsi.ts
@@ -73,7 +73,7 @@ async function createEtsiVerificationSession(ctx: CommandContext): Promise<void>
   ctx.saveJson('create-etsi-verification-session-request.json', request, step);
   
   const response = await ctx.orgClient.post(
-    `/v1/${ctx.tenantPath}.${RESOURCES.verifier2}/verifier2-service-api/verification-session/create`,
+    `/v2/${ctx.tenantPath}.${RESOURCES.verifier2}/verifier-service-api/verification-session/create`,
     request
   );
   ctx.saveJson('create-etsi-verification-session-response.json', response.data, step);

--- a/cli/src/flows/gov-trust.ts
+++ b/cli/src/flows/gov-trust.ts
@@ -30,6 +30,9 @@ import {
 
 /** Extract stored wallet credential IDs from a receive response. */
 function extractStoredCredentialIds(receiveResponse: unknown): string[] {
+  if (Array.isArray((receiveResponse as any)?.credentialIds)) {
+    return (receiveResponse as any).credentialIds.filter((id: unknown): id is string => typeof id === 'string');
+  }
   if (!Array.isArray(receiveResponse)) {
     return [];
   }
@@ -73,9 +76,7 @@ async function walletReceiveWithTrust(
   const request = {
     offerUrl,
     keyReference: ctx.ctx.walletKeyRef,
-    didReference: defaultWalletDidReference(ctx.tenantPath),
-    runPolicies: true,
-    useClientAttestation: false,
+    did: defaultWalletDidReference(ctx.tenantPath),
   };
   ctx.saveJson('wallet-receive-trust-request.json', request, step);
 
@@ -86,7 +87,7 @@ async function walletReceiveWithTrust(
     );
     ctx.saveJson('wallet-receive-trust-response.json', response.data, step);
 
-    const receivedCount = Array.isArray(response.data) ? response.data.length : 0;
+    const receivedCount = extractStoredCredentialIds(response.data).length;
     const credentialIds = extractStoredCredentialIds(response.data);
     console.log(`   [OK] Credential received (count: ${receivedCount})`);
     console.log(`        Credential IDs: ${credentialIds.join(', ')}`);
@@ -107,9 +108,7 @@ async function walletReceiveBypassTrust(
   const request = {
     offerUrl,
     keyReference: ctx.ctx.walletKeyRef,
-    didReference: defaultWalletDidReference(ctx.tenantPath),
-    runPolicies: false,
-    useClientAttestation: false,
+    did: defaultWalletDidReference(ctx.tenantPath),
   };
   ctx.saveJson('wallet-receive-no-trust-request.json', request, step);
 
@@ -119,7 +118,7 @@ async function walletReceiveBypassTrust(
   );
   ctx.saveJson('wallet-receive-no-trust-response.json', response.data, step);
 
-  const receivedCount = Array.isArray(response.data) ? response.data.length : 0;
+  const receivedCount = extractStoredCredentialIds(response.data).length;
   const credentialIds = extractStoredCredentialIds(response.data);
   console.log(`   [OK] Credential received (count: ${receivedCount})`);
   console.log(`        Credential IDs: ${credentialIds.join(', ')}`);
@@ -168,7 +167,7 @@ async function createTrustedVerifierSession(ctx: CommandContext): Promise<void> 
   ctx.saveJson('trusted-verifier-session-request.json', request, step);
 
   const response = await ctx.orgClient.post(
-    `/v1/${ctx.tenantPath}.${RESOURCES.verifier2}/verifier2-service-api/verification-session/create`,
+    `/v2/${ctx.tenantPath}.${RESOURCES.verifier2}/verifier-service-api/verification-session/create`,
     request
   );
   ctx.saveJson('trusted-verifier-session-response.json', response.data, step);
@@ -225,7 +224,7 @@ async function createUntrustedVerifierSession(
   ctx.saveJson('untrusted-verifier-session-request.json', request, step);
 
   const response = await ctx.orgClient.post(
-    `/v1/${verifierPath}/verifier2-service-api/verification-session/create`,
+    `/v2/${verifierPath}/verifier-service-api/verification-session/create`,
     request
   );
   ctx.saveJson('untrusted-verifier-session-response.json', response.data, step);

--- a/cli/src/flows/trust-list-assurance.ts
+++ b/cli/src/flows/trust-list-assurance.ts
@@ -203,6 +203,9 @@ async function testSignedLote(ctx: CommandContext): Promise<void> {
 }
 
 function extractCredentialIds(receiveResponse: any): string[] {
+  if (Array.isArray(receiveResponse?.credentialIds)) {
+    return receiveResponse.credentialIds.filter((id: unknown) => typeof id === 'string');
+  }
   if (!Array.isArray(receiveResponse)) return [];
   return receiveResponse.flatMap(result =>
     Array.isArray(result?.stored)
@@ -254,8 +257,6 @@ async function testVerifierIntegration(
   const receiveRequest = {
     offerUrl,
     keyReference: ctx.ctx.walletKeyRef,
-    runPolicies: false,
-    useClientAttestation: true,
   };
   ctx.saveJson('trust-list-wallet-receive-request.json', receiveRequest, step);
   const receiveResponse = await ctx.orgClient.post(
@@ -297,7 +298,7 @@ async function testVerifierIntegration(
   };
   ctx.saveJson('trust-list-verification-session-request.json', sessionRequest, step);
   const sessionResponse = await ctx.orgClient.post(
-    `/v1/${ctx.tenantPath}.${RESOURCES.verifier2}/verifier2-service-api/verification-session/create`,
+    `/v2/${ctx.tenantPath}.${RESOURCES.verifier2}/verifier-service-api/verification-session/create`,
     sessionRequest
   );
   ctx.saveJson('trust-list-verification-session-response.json', sessionResponse.data, step);
@@ -309,7 +310,7 @@ async function testVerifierIntegration(
 
   step = ctx.nextStep();
   const infoResponse = await ctx.orgClient.get(
-    `/v1/${ctx.tenantPath}.${RESOURCES.verifier2}.${ctx.ctx.sessionId}/verifier2-service-api/verification-session/info`
+    `/v2/${ctx.tenantPath}.${RESOURCES.verifier2}.${ctx.ctx.sessionId}/verifier-service-api/verification-session/info`
   );
   ctx.saveJson('trust-list-final-session-info.json', infoResponse.data, step);
   const session = infoResponse.data.session;


### PR DESCRIPTION
# Enterprise Stack Breaking Changes (CLI migration)

This targets commit https://github.com/walt-id/waltid-identity-enterprise/commit/a9b960b9ddc976e3dc96b2cddb8f1659bd93cf92 on the ES

This document lists API contract changes discovered while updating the walt.id Enterprise CLI against the current Enterprise API. Use it when migrating existing integrations.

Each entry records what changed (URL, request body, or response), why the previous call failed, and the replacement.

---

## Database initialization

### `POST /v1/admin/initial-setup` → `POST /v1/dev/initial-setup`

- **What failed:** `404 Not Found` on `/v1/admin/initial-setup`.
- **Change:** The development setup endpoint lives under the `dev-mode` feature at `/v1/dev/initial-setup`. `POST /v1/dev/database-recreate` already drops and sets up collections, so a separate initial-setup call is only needed when you did not recreate the database.
- **Replacement:** `POST /v1/dev/initial-setup` (no body). Requires the `dev-mode` feature.

---

## Wallet service

### Legacy `init-wallet` removed (Wallet1 / `wallet-draft-routes`)

- **What failed:** `POST /v1/{org}.{tenant}/wallet-service-api/init-wallet` returned `404 Not Found`.
- **Change:** Wallet1 `init-wallet` is disabled unless the `wallet-draft-routes` feature is enabled. The supported replacement is Wallet2 composable init, which creates a `wallet2` service plus optional KMS, DID store/service, and credential store in one request.
- **Old URL:** `POST /v1/{org}.{tenant}/wallet-service-api/init-wallet`
- **New URL:** `POST /v1/{org}.{tenant}/resource-api/services/init`
- **Old body (example):**

```json
{
  "createKeyInKms": { "keyType": "secp256r1" },
  "createDidWithDidService": "jwk",
  "kmsName": "wallet-kms",
  "didStoreName": "wallet-didstore",
  "didServiceName": "wallet-did-service",
  "credentialStoreName": "wallet-credentialstore"
}
```

- **New body (example):**

```json
{
  "wallet": {
    "createIfNotFound": true,
    "target": "{org}.{tenant}.wallet",
    "kms": {
      "createIfNotFound": true,
      "target": "{org}.{tenant}.wallet-kms",
      "key": {
        "createIfNotFound": true,
        "target": "{org}.{tenant}.wallet-kms.wallet_key",
        "config": { "backend": "jwk", "keyType": "secp256r1" }
      }
    },
    "didStore": {
      "createIfNotFound": true,
      "target": "{org}.{tenant}.wallet-didstore"
    },
    "didService": {
      "createIfNotFound": true,
      "target": "{org}.{tenant}.wallet-did-service",
      "dependencies": [
        "{org}.{tenant}.wallet-kms",
        "{org}.{tenant}.wallet-didstore"
      ],
      "did": {
        "createIfNotFound": true,
        "target": "{org}.{tenant}.wallet-didstore.wallet_did",
        "type": "jwk"
      }
    },
    "credentialStore": {
      "createIfNotFound": true,
      "target": "{org}.{tenant}.wallet-credentialstore"
    }
  }
}
```

- **Response:** `201 Created` with a `wallet` result object (`created` flags per child resource). The service type is `wallet2`, not `wallet`.
- **Follow-up:** Wallet2 protocol routes are under `/v2/{org}.{tenant}.wallet/wallet-service-api/...` (not `/v1`).

### Wallet2 protocol routes moved to `/v2`

- **What failed:** Wallet1 paths under `/v1/{wallet}/wallet-service-api/...` return `404` for a `wallet2` service.
- **Change:** Receive, present, client attestation, and dependency routes for Wallet2 are versioned at `/v2`.
- **Examples:**
  - Obtain attestation: `POST /v2/{org}.{tenant}.wallet/wallet-service-api/client-attestation/obtain`
  - Receive (pre-authorized): `POST /v2/{org}.{tenant}.wallet/wallet-service-api/credentials/receive/pre-authorized`
  - Present: `POST /v2/{org}.{tenant}.wallet/wallet-service-api/credentials/present`
- **Receive body:** `useClientAttestation` and `runPolicies` are no longer request fields. Client attestation is used automatically when the issuer advertises it and the wallet has a linked client attester. Provide `offerUrl` (or `offerJson`) and optional `keyReference` / `did`.
- **Receive response:** Previously an array of stored credential objects. Now an object:

```json
{ "credentialIds": ["<id>"], "deferredTransactionIds": {} }
```

- **Present body:** `didReference` is now `did` (inline DID string or DID-store reference). `keyReference` remains a KMS target path. The full-flow present endpoint no longer accepts a `credentials` array; it DCQL-matches from the wallet credential store. To present inline credentials, use `POST /v2/{wallet}/wallet-service-api/credentials/present/isolated`.

---

## Service dependencies

### `POST .../dependencies/add` body is JSON, not a raw path string

- **What failed:** `400 Bad Request` — `Failed to convert request body to ServiceDependencyRequest`.
- **Change:** Dependency add/remove no longer accept a `text/plain` (or JSON-encoded) target path string. The body is a JSON object.
- **Old body:** `"org.tenant.kms"` (raw string, often sent as `Content-Type: text/plain`)
- **New body:**

```json
{ "dependency": "org.tenant.kms" }
```

- **URL:** Unchanged for most v1 services (`POST /v1/{service}/...-api/dependencies/add`). Wallet2 and Verifier2 use their `/v2/...` service APIs (see below).
- **Response:** `201 Created` with a short confirmation string (for example `KeyManagementServiceReference attached`).

---

## Verifier2

### Protocol routes moved to `/v2/.../verifier-service-api`

- **What failed:** `POST /v1/{org}.{tenant}.verifier2/verifier2-service-api/dependencies/add` returned `404 Not Found`.
- **Change:** Verifier2 external routes are version `v2` and the path segment is `verifier-service-api` (no `2` in the service name).
- **Old URL pattern:** `/v1/{target}/verifier2-service-api/{endpoint}`
- **New URL pattern:** `/v2/{target}/verifier-service-api/{endpoint}`
- **Examples:**
  - Add dependency: `POST /v2/{org}.{tenant}.verifier2/verifier-service-api/dependencies/add`
  - Create session: `POST /v2/{org}.{tenant}.verifier2/verifier-service-api/verification-session/create`
  - Session info: `GET /v2/{org}.{tenant}.verifier2.{sessionId}/verifier-service-api/verification-session/info`
- **Service create URL is unchanged:** `POST /v1/{org}.{tenant}.verifier2/resource-api/services/create` with `"type": "verifier2"`.

---

## DID service

### Create DID request field `keyId` → `keyReference`

- **What failed:** `400 Bad Request` — `Request body contains unknown field(s): keyId` (`expectedType: CreateDidKeyRequest`).
- **Change:** `CreateDidKeyRequest` and `CreateDidJwkRequest` take `keyReference` (KMS target path) or an inline `key`, not `keyId`.
- **Old body:** `{ "keyId": "org.tenant.kms.signing-key" }`
- **New body:** `{ "keyReference": "org.tenant.kms.signing-key" }`
- **URL unchanged:** `POST /v1/{org}.{tenant}.{did-service}/did-service-api/dids/create/key` (and `/create/jwk`, `/create/web`).
- **Response:** `{ "id": "<did-store-target>", "did": "did:key:...", "document": { ... } }`

---

## Verifier2 session setup (OIDC Bridge / DC API)

### `flow_type: "dc_api"` → `"dc_api_openid4vp"`

- **What failed:** `400 Bad Request` — `Serializer for subclass 'dc_api' is not found in the polymorphic scope of 'VerificationSessionSetup'`.
- **Change:** Digital Credentials API sessions are now split into OpenID4VP Annex D (`dc_api_openid4vp`) and ISO 18013-7 Annex C (`dc_api_18013_7`). The nested common config field is `core_flow` (same as `cross_device`), not `core`.
- **Old body (excerpt):**

```json
{
  "flow_type": "dc_api",
  "core": { "dcql_query": { } },
  "expectedOrigins": ["https://example.com"],
  "haip": false
}
```

- **New body (excerpt):**

```json
{
  "flow_type": "dc_api_openid4vp",
  "core_flow": { "dcql_query": { } },
  "expectedOrigins": ["https://example.com"],
  "haip": false
}
```

- **Constraint:** `expectedOrigins` must be HTTPS secure-context origins (no trailing slash). HTTP local origins are rejected.

---

## Verification

Verified against a local Enterprise API (`./gradlew :waltid-enterprise-api:run`) with MongoDB:

| Command | Result |
| --- | --- |
| `--recreate` (system init + setup-all + issue/verify mDL) | Pass |
| `--flow-etsi-trust-lists` | Pass |
| `--flow-trust-list-assurance` | Pass (signed LoTE skipped: no `TRUST_LIST_SIGNED_LOTE_FILE`) |
| `--flow-credential-revocation` | Pass |
| `--setup-bank-tenant` | Pass |
| `--setup-gov-services` | Pass |
| `--setup-create-oidc-bridge` | Pass (DC API flow disabled on HTTP local origin) |
| `--flow-gov-trust` | Not verified: issuers used `GOV_SERVICES_BASE_URL` pointing at an offline ngrok tunnel, so the wallet could not fetch the credential offer |
| `--setup-eudi-demo` | Not run (requires WRP Registry credentials and a live public URL) |

---
